### PR TITLE
Offline build support for Bzlmod

### DIFF
--- a/mozc-deps.yaml
+++ b/mozc-deps.yaml
@@ -1,60 +1,92 @@
 - type: file
-  url: https://github.com/bazelbuild/apple_support/releases/download/1.12.0/apple_support.1.12.0.tar.gz
+  url: https://github.com/JetBrains/kotlin/releases/download/v1.9.22/kotlin-compiler-1.9.22.zip
   dest: bazel-deps
-  sha256: 100d12617a84ebc7ee7a10ecf3b3e2fdadaebc167ad93a21f820a6cb60158ead
+  sha256: 88b39213506532c816ff56348c07bbeefe0c8d18943bffbad11063cf97cac3e6
 - type: file
-  url: https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip
+  url: https://github.com/bazel-contrib/bazel_features/releases/download/v1.13.0/bazel_features-v1.13.0.tar.gz
   dest: bazel-deps
-  sha256: cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806
+  sha256: 5d7e4eb0bb17aee392143cd667b67d9044c270a9345776a5e5a3cccbc44aa4b3
 - type: file
-  url: https://github.com/bazelbuild/rules_android_ndk/archive/44dcd014f4b126f8941c29ff1b25e1584bd3eb26.zip
+  url: https://github.com/bazelbuild/apple_support/releases/download/1.16.0/apple_support.1.16.0.tar.gz
   dest: bazel-deps
-  sha256: 79b1857e8e05e3007ad090a3269d2932e988b3ed176d7abd042719d45eb51500
+  sha256: c31ce8e531b50ef1338392ee29dd3db3689668701ec3237b9c61e26a1937ab07
 - type: file
-  url: https://github.com/bazelbuild/rules_apple/releases/download/3.1.1/rules_apple.3.1.1.tar.gz
+  url: https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz
   dest: bazel-deps
-  sha256: 34c41bfb59cdaea29ac2df5a2fa79e5add609c71bb303b2ebb10985f93fa20e7
+  sha256: bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f
 - type: file
-  url: https://github.com/bazelbuild/rules_cc/archive/c8c38f8c710cbbf834283e4777916b68261b359c.zip
+  url: https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz
   dest: bazel-deps
-  sha256: 5f862a44bbd032e1b48ed53c9c211ba2a1da60e10c5baa01c97369c249299ecb
+  sha256: 218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee
+- type: file
+  url: https://github.com/bazelbuild/rules_android/releases/download/v0.5.1/rules_android-v0.5.1.tar.gz
+  dest: bazel-deps
+  sha256: b1599e4604c1594a1b0754184c5e50f895a68f444d1a5a82b688b2370d990ba0
+- type: file
+  url: https://github.com/bazelbuild/rules_android_ndk/releases/download/v0.1.2/rules_android_ndk-v0.1.2.tar.gz
+  dest: bazel-deps
+  sha256: 65aedff0cd728bee394f6fb8e65ba39c4c5efb11b29b766356922d4a74c623f5
+- type: file
+  url: https://github.com/bazelbuild/rules_apple/releases/download/3.5.1/rules_apple.3.5.1.tar.gz
+  dest: bazel-deps
+  sha256: b4df908ec14868369021182ab191dbd1f40830c9b300650d5dc389e0b9266c8d
+- type: file
+  url: https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz
+  dest: bazel-deps
+  sha256: 2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf
+- type: file
+  url: https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip
+  dest: bazel-deps
+  sha256: 33acc4ae0f70502db4b893c9fc1dd7a9bf998c23e7ff2c4517741d4049a976f8
+- type: file
+  url: https://github.com/bazelbuild/rules_java/releases/download/7.9.0/rules_java-7.9.0.tar.gz
+  dest: bazel-deps
+  sha256: 41131de4417de70b9597e6ebd515168ed0ba843a325dc54a81b92d7af9a7b3ea
+- type: file
+  url: https://github.com/bazelbuild/rules_kotlin/releases/download/v1.9.5/rules_kotlin-v1.9.5.tar.gz
+  dest: bazel-deps
+  sha256: 34e8c0351764b71d78f76c8746e98063979ce08dcf1a91666f3f3bc2949a533d
 - type: file
   url: https://github.com/bazelbuild/rules_license/releases/download/0.0.7/rules_license-0.0.7.tar.gz
   dest: bazel-deps
   sha256: 4531deccb913639c30e5c7512a054d5d875698daeb75d8cf90f284375fe7c360
 - type: file
-  url: https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz
-  dest: bazel-deps
-  sha256: dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd
-- type: file
-  url: https://github.com/bazelbuild/rules_python/releases/download/0.0.1/rules_python-0.0.1.tar.gz
-  dest: bazel-deps
-  sha256: aa96a691d3a8177f3215b14b0edc9641787abaaa30363a080165d06ab65e1161
-- type: file
-  url: https://github.com/bazelbuild/rules_swift/releases/download/1.13.0/rules_swift.1.13.0.tar.gz
-  dest: bazel-deps
-  sha256: 28a66ff5d97500f0304f4e8945d936fe0584e0d5b7a6f83258298007a93190ba
-- type: file
-  url: https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.xz
-  dest: bazel-deps
-  sha256: d14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98
-- type: file
-  url: https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz
-  dest: bazel-deps
-  sha256: b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7
-- type: file
-  url: https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.7/platforms-0.0.7.tar.gz
-  dest: bazel-deps
-  sha256: 3a561c99e7bdbe9173aa653fd579fe849f1d8d67395780ab4770b1f381431d51
-- type: file
-  url: https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz
+  url: https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz
   dest: bazel-deps
   sha256: 8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2
 - type: file
+  url: https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz
+  dest: bazel-deps
+  sha256: 303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d
+- type: file
+  url: https://github.com/bazelbuild/rules_python/releases/download/0.34.0/rules_python-0.34.0.tar.gz
+  dest: bazel-deps
+  sha256: 778aaeab3e6cfd56d681c89f5c10d7ad6bf8d2f1a72de9de55b23081b2d31618
+- type: file
+  url: https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz
+  dest: bazel-deps
+  sha256: bb01097c7c7a1407f8ad49a1a0b1960655cf823c26ad2782d0b7d15b323838e2
+- type: file
+  only-arches:
+    - x86_64
+  url: https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.11.9+20240415-x86_64-unknown-linux-gnu-install_only.tar.gz
+  dest: bazel-deps
+  sha256: 78b1c16a9fd032997ba92a60f46a64f795cd18ff335659dfdf6096df277b24d5
+- type: file
+  only-arches:
+    - aarch64
+  url: https://github.com/indygreg/python-build-standalone/releases/download/20240415/cpython-3.11.9+20240415-aarch64-unknown-linux-gnu-install_only.tar.gz
+  dest: bazel-deps
+  sha256: b3a7199ac2615d75fb906e5ba556432efcf24baf8651fc70370d9f052d4069ee
+- type: file
+  url: https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
+  dest: bazel-deps
+  sha256: 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+- type: file
   url: https://www.post.japanpost.jp/zipcode/dl/jigyosyo/zip/jigyosyo.zip
   dest: bazel-deps
-  sha256: ef1505916652d7612a74ef94bafe93361f207c8a33ed4b8153c5eeb378d25514
+  sha256: 1ef5d43b5e5bf059117a2570fe95e0a9e3cf8a27f3e3882da283ad18460d2264
 - type: file
   url: https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/ken_all.zip
   dest: bazel-deps
-  sha256: 29788f5b893befa748de333551884596437f2fa4233c53e9121b56f6f7dff109
+  sha256: 85f13da74bf178ecb18083ec6d31e63bc4395c7817c3bb3587c7e86707609d2a

--- a/org.fcitx.Fcitx5.Addon.Mozc.yaml
+++ b/org.fcitx.Fcitx5.Addon.Mozc.yaml
@@ -4,38 +4,62 @@ runtime: org.fcitx.Fcitx5
 runtime-version: stable
 sdk: org.kde.Sdk//6.6
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.llvm17
-  - org.freedesktop.Sdk.Extension.bazel
+  - org.freedesktop.Sdk.Extension.llvm18
 build-extension: true
 separate-locales: false
 build-options:
   prefix: /app/addons/Mozc
-  prepend-path: /usr/lib/sdk/llvm17/bin:/usr/lib/sdk/bazel/bin
+  prepend-path: /usr/lib/sdk/llvm18/bin:/app/addons/Mozc/bazel/bin
   prepend-pkg-config-path: /app/addons/Mozc/lib/pkgconfig
-  prepend-ld-library-path: /usr/lib/sdk/llvm17/lib
+  prepend-ld-library-path: /usr/lib/sdk/llvm18/lib
   env:
     - server_dir=/app/addons/Mozc/lib/mozc
     - document_dir=/app/ime/mozc/licenses/mozc
     - icons_dir=/app/share/icons/mozc
     - LOCALE=C.UTF-8
+    - CC=clang
+    - CXX=clang++
 cleanup:
   - /bin
   - /include
   - /lib/pkgconfig
+  - /app/addons/Mozc/bazel
   - '*.la'
 modules:
+  - name: bazel
+    buildsystem: simple
+    build-commands:
+      - install -D bazel ${FLATPAK_DEST}/bazel/bin/bazel
+    sources:
+      - type: file
+        only-arches:
+          - x86_64
+        url: https://github.com/bazelbuild/bazel/releases/download/7.3.1/bazel-7.3.1-linux-x86_64
+        sha256: 794f58b5a5c28c4729f04db0bd1238eaf827105bb49946238b00f681a1da377c
+        dest-filename: bazel
+      - type: file
+        only-arches:
+          - aarch64
+        url: https://github.com/bazelbuild/bazel/releases/download/7.3.1/bazel-7.3.1-linux-arm64
+        sha256: 95871a3dc9db88043fb54752ce2155d702bbad809b0e5f0c428a67c0522e5944
+        dest-filename: bazel
   - name: mozc
     buildsystem: simple
     subdir: src
     build-commands:
-      - ../scripts/build_fcitx5_bazel --distdir=$PWD/../bazel-deps --linkopt "${LDFLAGS}"
-        && PREFIX=${FLATPAK_DEST} ../scripts/install_server_bazel && PREFIX=${FLATPAK_DEST}
-        ../scripts/install_fcitx5_bazel
+      - export BAZEL_LDFLAGS=$(echo ${LDFLAGS}|xargs -n1 echo "--linkopt") &&
+        ../scripts/build_fcitx5_bazel --config release_build --registry=file:///$PWD/../bcr --distdir=$PWD/../bazel-deps ${BAZEL_LDFLAGS} &&
+        PREFIX=${FLATPAK_DEST} ../scripts/install_server_bazel &&
+        PREFIX=${FLATPAK_DEST} ../scripts/install_fcitx5_bazel
     sources:
       - type: git
         url: https://github.com/fcitx/mozc
         disable-shallow-clone: true
-        commit: e379550bcdfd5f54507a8ad3d95f20cb9e0385fb
+        commit: a47ae1c27546bb27b7517184cbbd63e0b6b95138
+      - type: git
+        url: https://github.com/bazelbuild/bazel-central-registry
+        dest: bcr
+        commit: 25a70ad064095de78e280af819f1d75d459c7c02
       - type: patch
         path: zip-code.patch
       - type: shell

--- a/update_mozc_commit
+++ b/update_mozc_commit
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+function UpdateGitCommit() {
+    local url=$1
+    local new_commit=$2
+    temp_file=$(mktemp)
+    jq '
+    def update_git_commit(url; new_commit):
+    walk(
+        if type == "object" and .type == "git" and .url == url then
+            del(.branch) | .commit = new_commit
+        else
+            .
+        end
+    );
+
+    update_git_commit("'$url'" ; "'$new_commit'")
+    ' input.json > ${temp_file}
+    mv ${temp_file} input.json
+    sync
+}
+
+
+# commit update of git source
+
+# Fcitx5
+yq "." org.fcitx.Fcitx5.Addon.Mozc.yaml > input.json
+pushd .
+GIT_URL=https://github.com/fcitx/mozc
+[[ ! -d mozc ]] && git clone --filter=tree:0 $GIT_URL
+cd mozc/src
+git fetch --all
+git checkout origin/fcitx
+GIT_COMMIT=$(git log -1 --pretty=%H)
+popd
+UpdateGitCommit $GIT_URL $GIT_COMMIT
+
+# bcr
+pushd .
+GIT_URL=https://github.com/bazelbuild/bazel-central-registry
+[[ ! -d bcr ]] && git clone --filter=tree:0 $GIT_URL bcr
+cd bcr
+git fetch --all
+git checkout origin/main
+GIT_COMMIT=$(git log -1 --pretty=%H)
+popd
+UpdateGitCommit $GIT_URL $GIT_COMMIT
+
+yq -y "." input.json > org.fcitx.Fcitx5.Addon.Mozc.yaml

--- a/zip-code.patch
+++ b/zip-code.patch
@@ -1,12 +1,34 @@
 diff --git a/src/config.bzl b/src/config.bzl
-index 11bb88ea8..cdb2e6269 100644
+index 2675e04..7336fbe 100644
 --- a/src/config.bzl
 +++ b/src/config.bzl
-@@ -60,5 +60,5 @@ MACOS_QT_PATH = "/usr/local/Qt-6.5.2"
+@@ -71,5 +71,5 @@ MACOS_QT_PATH = "/usr/local/Qt-6.5.2"
  ## SHA256 of zip code files.
  # When zip code files are prefetched and used via --repository_cache for offline build,
  # SHA256 values should be specified.
 -SHA256_ZIP_CODE_KEN_ALL = None
 -SHA256_ZIP_CODE_JIGYOSYO = None
-+SHA256_ZIP_CODE_KEN_ALL = "29788f5b893befa748de333551884596437f2fa4233c53e9121b56f6f7dff109"
-+SHA256_ZIP_CODE_JIGYOSYO = "ef1505916652d7612a74ef94bafe93361f207c8a33ed4b8153c5eeb378d25514"
++SHA256_ZIP_CODE_KEN_ALL = "85f13da74bf178ecb18083ec6d31e63bc4395c7817c3bb3587c7e86707609d2a"
++SHA256_ZIP_CODE_JIGYOSYO = "1ef5d43b5e5bf059117a2570fe95e0a9e3cf8a27f3e3882da283ad18460d2264"
+diff --git a/src/MODULE.bazel b/src/MODULE.bazel
+index 577917e..ac6f1c9 100644
+--- a/src/MODULE.bazel
++++ b/src/MODULE.bazel
+@@ -261,7 +261,7 @@ http_archive(
+ #
+ # SHA256 as of 2024-08-14
+ # SHA256_ZIP_CODE_KEN_ALL = "d2d177ef64b9459a618d8aaa96b6c5f081cb3f37f6e9c00ba912001e66b81f3e"
+-SHA256_ZIP_CODE_KEN_ALL = None
++SHA256_ZIP_CODE_KEN_ALL = "85f13da74bf178ecb18083ec6d31e63bc4395c7817c3bb3587c7e86707609d2a"
+ http_archive(
+     name = "zip_code_ken_all",
+     build_file_content = "exports_files([\"KEN_ALL.CSV\"])",
+@@ -270,7 +270,7 @@ http_archive(
+ )
+ # SHA256 as of 2024-08-14
+ # SHA256_ZIP_CODE_JIGYOSYO="ab6fd92df35e63c4566d29f70456da1603d8178ce3fec073f7c27b28d0af2e10"
+-SHA256_ZIP_CODE_JIGYOSYO = None
++SHA256_ZIP_CODE_JIGYOSYO = "1ef5d43b5e5bf059117a2570fe95e0a9e3cf8a27f3e3882da283ad18460d2264"
+ http_archive(
+     name = "zip_code_jigyosyo",
+     build_file_content = "exports_files([\"JIGYOSYO.CSV\"])",


### PR DESCRIPTION
  Update org.fcitx.Fcitx5.Addon.Mozc to pr-commit-a47ae1c27546bb27b7517184cbbd63e0b6b95138

  Update mozc-deps.yaml

  Add bazel-central-registry to the sources.
  Add the --registry option to the bazel command.
  Add the --experimental_downloader_config option to the bazel command
  of update_mozc_deps
  Added MODULE.bazel to zip-code.patch for offline building with bzlmod.
  Added update_mozc_commit scripts.
  zip-code.patch updated

  bazel-7.1.1 -> bazel-7.3.1(github release) for bzlmod
  --linkopt: Only one flag is accepted per option.

  sdk-extensions: llvm17 -> llvm18

  remove sdk-extensions
    - org.freedesktop.Sdk.Extension.bazel